### PR TITLE
Feat/add-link-on-registration-page-to-naviagte-to-login-page-rss-ecomm-2_16

### DIFF
--- a/src/view/components/signup/signup-form.module.css
+++ b/src/view/components/signup/signup-form.module.css
@@ -75,3 +75,8 @@
   border-radius: 50%;
   background: linear-gradient(to right, rgba(255, 255, 255, 0.7) 0 100%);
 }
+
+.link a:last-child {
+  margin: 0 1rem;
+  font-size: 2rem;
+}

--- a/src/view/components/signup/signup-form.tsx
+++ b/src/view/components/signup/signup-form.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import React, { ChangeEvent, FormEvent, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { RegistrationFieldsType } from '../../../data/types/registration-type';
 import { validationField, setCostumerCountry } from '../../../data/utils/validate-signup-form';
 import InputField from './signup-form-input';
@@ -156,6 +157,9 @@ function FormSingup(props: IFormProps) {
   return (
     <div className={FormStyles.container}>
       <h2>Register</h2>
+      <p className={FormStyles.link}>
+        OR if you already have an account<Link to="/login">Login</Link>
+      </p>
       <form className={FormStyles.form} onSubmit={onSubmit}>
         <InputField
           label="Email"

--- a/src/view/pages/Signup/signup.tsx
+++ b/src/view/pages/Signup/signup.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import React, { FormEvent } from 'react';
-import { Link } from 'react-router-dom';
 import FormSingup from '../../components/signup/signup-form';
 import Header from '../../components/common/header/header';
 import * as SignupStyles from './signup.module.css';
@@ -19,9 +18,6 @@ export default function Singup({ showMsg, setShowMsg }: MainProps) {
       <div className={SignupStyles.signup}>
         <FormSingup onSubmit={handleRegistrationSubmit} />
       </div>
-      <p className={SignupStyles.link}>
-        Already have an account?<Link to="/login">Login</Link>
-      </p>
       <Footer />
     </>
   );


### PR DESCRIPTION
## Proposed Changes

- On the registration page, add a button or link that redirects users to the login page if they already have an account. This button or link should be easily noticeable and accessible, adhering to the best user interface design practices.

- Visual Implementation Ideas
Position the button or link strategically on the page so that it's easily noticeable. It could be placed below the registration form or near the top of the page for easy access.
The button or link could say something like "Already have an account? Login". 💬
Use contrasting colors or fonts to make the button or link stand out.

## Rationale behind the changes

- The registration page includes a clear and visible button or link
- Upon clicking the button or link, the user is redirected to the login page.

## Affected Components and Areas

- src/view/pages/Signup/signup.tsx

## Testing Performed

-

## Additional Notes

- 
